### PR TITLE
SCRUM-39 : 프론트엔드 픽셀 확정  서버 전송

### DIFF
--- a/src/components/SocketIntegration.tsx
+++ b/src/components/SocketIntegration.tsx
@@ -4,9 +4,10 @@ import { useSocket } from '../hooks/useSocket';
 interface SocketIntegrationProps {
   sourceCanvasRef: React.RefObject<HTMLCanvasElement>;
   draw: () => void;
+  canvas_id: string; //[*]
 }
 
-export const usePixelSocket = ({ sourceCanvasRef, draw }: SocketIntegrationProps) => {
+export const usePixelSocket = ({ sourceCanvasRef, draw, canvas_id }: SocketIntegrationProps) => { //[*]
   // 다른 사용자 픽셀 수신
   const handlePixelReceived = useCallback((pixel: { x: number; y: number; color: string }) => {
     const sourceCtx = sourceCanvasRef.current?.getContext('2d');
@@ -29,7 +30,7 @@ export const usePixelSocket = ({ sourceCanvasRef, draw }: SocketIntegrationProps
     }
   }, [sourceCanvasRef, draw]);
 
-  const { sendPixel } = useSocket(handlePixelReceived, handleCanvasReceived);
+  const { sendPixel } = useSocket(handlePixelReceived, handleCanvasReceived, canvas_id); //[*]
 
   return { sendPixel };
 };

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -9,16 +9,17 @@ interface PixelData {
 
 export const useSocket = (
   onPixelReceived: (pixel: PixelData) => void,
-  onCanvasReceived: (canvasData: string) => void
+  onCanvasReceived: (canvasData: PixelData[]) => void,
+  canvas_id: string
 ) => {
   const isConnected = useRef(false);
 
   useEffect(() => {
     if (!isConnected.current) {
-      socketService.connect();
+      socketService.connect(canvas_id);
       socketService.onPixelUpdate(onPixelReceived);
       socketService.onCanvasData(onCanvasReceived);
-      socketService.requestCanvasData();
+      socketService.requestCanvasData(canvas_id);
       isConnected.current = true;
     }
 
@@ -26,10 +27,10 @@ export const useSocket = (
       socketService.disconnect();
       isConnected.current = false;
     };
-  }, [onPixelReceived, onCanvasReceived]);
+  }, [onPixelReceived, onCanvasReceived, canvas_id]);
 
   const sendPixel = (pixel: PixelData) => {
-    socketService.drawPixel(pixel);
+    socketService.drawPixel({ ...pixel, canvas_id });
   };
 
   return { sendPixel };

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -6,14 +6,21 @@ interface PixelData {
   color: string;
 }
 
+interface PixelDataWithCanvas extends PixelData {
+  canvas_id: string;
+}
+
 class SocketService {
   private socket: Socket | null = null;
+  private currentCanvasId: string = '';
 
-  connect() {
+  connect(canvas_id: string) {
+    this.currentCanvasId = canvas_id;
     this.socket = io('http://localhost:3000');
     
     this.socket.on('connect', () => {
       console.log('소켓 연결됨');
+      this.socket!.emit('join', { canvas_id: this.currentCanvasId });
     });
 
     this.socket.on('disconnect', () => {
@@ -22,7 +29,7 @@ class SocketService {
   }
 
   // 픽셀 그리기 서버로 전송
-  drawPixel(pixelData: PixelData) {
+  drawPixel(pixelData: PixelDataWithCanvas) {
     if (this.socket) {
       this.socket.emit('draw-pixel', pixelData);
     }
@@ -36,14 +43,14 @@ class SocketService {
   }
 
   // 초기 캔버스 데이터 요청
-  requestCanvasData() {
+  requestCanvasData(canvas_id: string) {
     if (this.socket) {
-      this.socket.emit('get-canvas');
+      this.socket.emit('get-canvas', { canvas_id });
     }
   }
 
   // 초기 캔버스 데이터 수신
-  onCanvasData(callback: (canvasData: string) => void) {
+  onCanvasData(callback: (canvasData: PixelData[]) => void) {
     if (this.socket) {
       this.socket.on('canvas-data', callback);
     }


### PR DESCRIPTION
develop 브랜치에서 풀 받은 상태에서 픽셀 확정 버튼 클릭 시 서버로 데이터를 전송 기능을 구현했습니다. 기존에는 픽셀 확정 버튼을 눌러도 로컬에서만 임시 표시되고 서버로 전송되지 않았으나, 이제 canvas_id가 포함된 픽셀 데이터가 서버로 전송됩니다.

frontend/src/services/socketService.ts

canvas_id 변수 미정의 문제 해결을 위해 connect() 메서드에 canvas_id 파라미터 추가
drawPixel() 메서드의 타입을 PixelDataWithCanvas로 변경하여 canvas_id 포함
requestCanvasData() 메서드에 canvas_id 파라미터 추가
onCanvasData() 콜백의 타입을 PixelData[]로 수정
currentCanvasId 프로퍼티 추가로 캔버스별 연결 관리
frontend/src/hooks/useSocket.ts

잘못된 import 제거 (순환 참조 방지)
onCanvasReceived 콜백 타입을 PixelData[]로 수정
requestCanvasData() 호출 시 canvas_id 전달
useEffect 의존성 배열에 canvas_id 추가
frontend/src/components/PixelCanvas.tsx

usePixelSocket import 추가
sourceCanvasRef 타입을 HTMLCanvasElement로 수정 (null! 사용)
usePixelSocket 훅 사용하여 소켓 연결 및 픽셀 전송 기능 추가
handleConfirm 함수에서 sendPixel() 호출하여 서버로 픽셀 데이터 전송
handleConfirm 의존성 배열에 sendPixel 추가
픽셀 확정 버튼 클릭 → handleConfirm() 호출 → sendPixel() 호출 → useSocket의 sendPixel() 실행 → socketService.drawPixel() 호출 → 서버로 'draw-pixel' 이벤트 전송 → 서버에서 Redis/메모리에 저장 → 같은 canvas_id 방의 모든 클라이언트에게 'pixel-update' 브로드캐스트

아까 말했던 대로 프론트엔드 App.tsx에서 canvas_id를 명시적으로 전달해야 올바른 방식이지만, 현재는 백엔드에서 기본값 처리로 인해 동작하긴 하는것 같습니다. main.tsx에 canvas_id={canvas_id} 부분 필요하지만 이 코드에는 반영되어 있지 않습니다.