### PR TITLE
[SCRUM-46] 캔버스 웹소켓 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,9 @@
 
 import PixelCanvas from './components/PixelCanvas';
 
-import { useState, useEffect } from 'react'; // UI 상태 관리를 위해 import
+import React, { useState, useEffect } from 'react'; // UI 상태 관리를 위해 import
+import { useLocation } from 'react-router-dom';
+
 import { useModalStore } from './store/modalStore';
 import LoginModalContent from './components/modal/LoginModalContent';
 import Modal from './components/modal/Modal';
@@ -12,11 +14,19 @@ import apiClient from './services/apiClient';
 type HoverPos = { x: number; y: number } | null;
 
 function App() {
+  // URL에서 ?canvas_id= 값을 읽어온다
+  const { search } = useLocation();
+  const canvas_id = new URLSearchParams(search).get('canvas_id') || '';
+
   // UI와 캔버스가 공유해야 할 상태들을 App에서 관리 => 색상 정보 및 cursor 가 가리키는 픽셀 정보
   const [color, setColor] = useState('#ffffff');
   const [hoverPos, setHoverPos] = useState<HoverPos>(null);
   const colors = ['#ffffff', '#000000', '#ff0000', '#00ff00', '#0000ff']; // 예시 색상
   const { isLoginModalOpen, closeLoginModal } = useModalStore();
+
+  // if (!canvas_id) {
+  //   return <div className='text-red-500'> canvas_id 쿼리가 필요합니다.</div>;
+  // }
 
   const { isLoggedIn, setAuth, clearAuth } = useAuthStore();
   const [isLoading, setIsLoading] = useState(true);
@@ -45,7 +55,7 @@ function App() {
         hoverPos={hoverPos}
         setHoverPos={setHoverPos}
         colors={colors}
-        canvas_id={''}
+        canvas_id={canvas_id}
       />
       <Modal isOpen={isLoginModalOpen} onClose={closeLoginModal}>
         <LoginModalContent onClose={closeLoginModal} />

--- a/src/components/PixelCanvas.tsx
+++ b/src/components/PixelCanvas.tsx
@@ -37,7 +37,7 @@ function PixelCanvas({
   const previewCanvasRef = useRef<HTMLCanvasElement>(null); // 반투명 오버레이용 캔버스
   const renderCanvasRef = useRef<HTMLCanvasElement>(null); // 색상 칠하는 아래층 Canvas
   const interactionCanvasRef = useRef<HTMLCanvasElement>(null); // 이벤트 레이어
-  const sourceCanvasRef = useRef<HTMLCanvasElement>(null!);
+  const sourceCanvasRef = useRef<HTMLCanvasElement | null>(null!);
 
   const scaleRef = useRef<number>(1);
   const viewPosRef = useRef<{ x: number; y: number }>(INITIAL_POSITION);
@@ -238,15 +238,12 @@ function PixelCanvas({
   const handleCooltime = useCallback(() => {
     // 20초 쿨타임 시작
     startCooldown(20);
-  }, []);
+  }, [startCooldown]);
 
   //===== 확정 버튼 클릭 핸들러
   const handleConfirm = useCallback(() => {
     const pos = fixedPosRef.current;
     if (!pos) return;
-
-    // 쿨타임 함수 호출
-    handleCooltime();
 
     // 쿨타임 함수 호출
     handleCooltime();
@@ -266,7 +263,7 @@ function PixelCanvas({
       pos.color = 'transparent';
       draw();
     }, 4000);
-  }, [color, draw, sendPixel]);
+  }, [color, draw, sendPixel, handleCooltime]);
 
   // 팔레트 변경 시 미리보기 픽셀 업데이트 - fixed pixel 색만 바꿔주고 draw()
   const handleSelectColor = useCallback(

--- a/src/components/SocketIntegration.tsx
+++ b/src/components/SocketIntegration.tsx
@@ -7,30 +7,26 @@ interface SocketIntegrationProps {
   canvas_id: string; //[*]
 }
 
-export const usePixelSocket = ({ sourceCanvasRef, draw, canvas_id }: SocketIntegrationProps) => { //[*]
+export const usePixelSocket = ({
+  sourceCanvasRef,
+  draw,
+  canvas_id,
+}: SocketIntegrationProps) => {
+  //[*]
   // 다른 사용자 픽셀 수신
-  const handlePixelReceived = useCallback((pixel: { x: number; y: number; color: string }) => {
-    const sourceCtx = sourceCanvasRef.current?.getContext('2d');
-    if (sourceCtx) {
-      sourceCtx.fillStyle = pixel.color;
-      sourceCtx.fillRect(pixel.x, pixel.y, 1, 1);
-      draw();
-    }
-  }, [sourceCanvasRef, draw]);
-
-  // 초기 캔버스 데이터 수신
-  const handleCanvasReceived = useCallback((pixels: Array<{ x: number; y: number; color: string }>) => {
-    const sourceCtx = sourceCanvasRef.current?.getContext('2d');
-    if (sourceCtx) {
-      pixels.forEach(pixel => {
+  const handlePixelReceived = useCallback(
+    (pixel: { x: number; y: number; color: string }) => {
+      const sourceCtx = sourceCanvasRef.current?.getContext('2d');
+      if (sourceCtx) {
         sourceCtx.fillStyle = pixel.color;
         sourceCtx.fillRect(pixel.x, pixel.y, 1, 1);
-      });
-      draw();
-    }
-  }, [sourceCanvasRef, draw]);
+        draw();
+      }
+    },
+    [sourceCanvasRef, draw]
+  );
 
-  const { sendPixel } = useSocket(handlePixelReceived, handleCanvasReceived, canvas_id); //[*]
+  const { sendPixel } = useSocket(handlePixelReceived, canvas_id); //[*]
 
   return { sendPixel };
 };

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -9,7 +9,6 @@ interface PixelData {
 
 export const useSocket = (
   onPixelReceived: (pixel: PixelData) => void,
-  onCanvasReceived: (canvasData: PixelData[]) => void,
   canvas_id: string
 ) => {
   const isConnected = useRef(false);
@@ -18,8 +17,6 @@ export const useSocket = (
     if (!isConnected.current) {
       socketService.connect(canvas_id);
       socketService.onPixelUpdate(onPixelReceived);
-      socketService.onCanvasData(onCanvasReceived);
-      socketService.requestCanvasData(canvas_id);
       isConnected.current = true;
     }
 
@@ -27,7 +24,7 @@ export const useSocket = (
       socketService.disconnect();
       isConnected.current = false;
     };
-  }, [onPixelReceived, onCanvasReceived, canvas_id]);
+  }, [onPixelReceived, canvas_id]);
 
   const sendPixel = (pixel: PixelData) => {
     socketService.drawPixel({ ...pixel, canvas_id });

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,7 +1,7 @@
 // src/router/Router.tsx (새 파일)
 
 import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import App from '../App';
 import AuthCallbackPage from '../auth/AuthCallbackPage';
 
@@ -9,7 +9,8 @@ export default function Router() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path='/' element={<App />} />
+        <Route path='/' element={<Navigate to='/canvas' replace />} />
+        <Route path='/canvas' element={<App />} />
         {/* ✨ OAuth 콜백을 처리할 전용 경로 */}
         <Route path='/auth/callback' element={<AuthCallbackPage />} />
         {/* 나중에 추가될 다른 페이지 경로들... */}

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -12,15 +12,13 @@ interface PixelDataWithCanvas extends PixelData {
 
 class SocketService {
   private socket: Socket | null = null;
-  private currentCanvasId: string = '';
 
   connect(canvas_id: string) {
-    this.currentCanvasId = canvas_id;
     this.socket = io('http://localhost:3000');
-    
+
     this.socket.on('connect', () => {
       console.log('소켓 연결됨');
-      this.socket!.emit('join', { canvas_id: this.currentCanvasId });
+      this.socket!.emit('join_canvas', { canvas_id: this.currentCanvasId });
     });
 
     this.socket.on('disconnect', () => {
@@ -39,20 +37,6 @@ class SocketService {
   onPixelUpdate(callback: (pixelData: PixelData) => void) {
     if (this.socket) {
       this.socket.on('pixel-update', callback);
-    }
-  }
-
-  // 초기 캔버스 데이터 요청
-  requestCanvasData(canvas_id: string) {
-    if (this.socket) {
-      this.socket.emit('get-canvas', { canvas_id });
-    }
-  }
-
-  // 초기 캔버스 데이터 수신
-  onCanvasData(callback: (canvasData: PixelData[]) => void) {
-    if (this.socket) {
-      this.socket.on('canvas-data', callback);
     }
   }
 


### PR DESCRIPTION
- /canvas 경로로 진입 시 URL 쿼리에서 canvas_id를 파싱해 PixelCanvas 컴포넌트에 prop으로 전달
- 불필요해진 useCanvas 래퍼 훅 제거 (CanvasReceived 관련)
- 소켓 함수 리팩터링