### PR TITLE
[SCRUM-61] 채팅 웹소켓 로직 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,7 +72,19 @@ function App() {
       <Modal isOpen={isMyPageModalOpen} onClose={closeMyPageModal}>
         <MyPageModalContent />
       </Modal>
-      <Chat />
+      {/* Chat 컴포넌트 에러 처리 */}
+      {(() => {
+        try {
+          return <Chat />;
+        } catch (error) {
+          console.error('Chat 컴포넌트 에러:', error);
+          return (
+            <div className='fixed bottom-5 left-5 text-red-500'>
+              채팅 로드 실패
+            </div>
+          );
+        }
+      })()}
     </main>
   );
 }

--- a/src/components/PixelCanvas.tsx
+++ b/src/components/PixelCanvas.tsx
@@ -342,7 +342,8 @@ function PixelCanvas({ canvas_id: initialCanvasId }: PixelCanvasProps) {
         canvasSize: fetchedCanvasSize,
       } = json.data;
 
-      // console.log(`fetchedID : ${fetchedId}`);
+      console.log(`fetchedID : ${fetchedId}`);
+      console.log(`pixels : ${pixels.length}`);
 
       setCanvasId(fetchedId);
       setCanvasSize(fetchedCanvasSize);

--- a/src/components/SocketIntegration.tsx
+++ b/src/components/SocketIntegration.tsx
@@ -1,10 +1,22 @@
 import { useCallback } from 'react';
 import { useSocket } from '../hooks/useSocket';
+import { useChatSocket as useChatSocketHook } from '../hooks/useChatSocket';
 
 interface SocketIntegrationProps {
   sourceCanvasRef: React.RefObject<HTMLCanvasElement>;
   draw: () => void;
-  canvas_id: string; //[*]
+  canvas_id: string;
+}
+
+interface ChatSocketProps {
+  onMessageReceived: (message: {
+    id: number;
+    user: { id: number; user_name: string };
+    message: string;
+    created_at: string;
+  }) => void;
+  group_id: string;
+  user_id: string;
 }
 
 export const usePixelSocket = ({
@@ -12,8 +24,6 @@ export const usePixelSocket = ({
   draw,
   canvas_id,
 }: SocketIntegrationProps) => {
-  //[*]
-  // 다른 사용자 픽셀 수신
   const handlePixelReceived = useCallback(
     (pixel: { x: number; y: number; color: string }) => {
       const sourceCtx = sourceCanvasRef.current?.getContext('2d');
@@ -26,7 +36,26 @@ export const usePixelSocket = ({
     [sourceCanvasRef, draw]
   );
 
-  const { sendPixel } = useSocket(handlePixelReceived, canvas_id); //[*]
+  const { sendPixel } = useSocket(handlePixelReceived, canvas_id);
 
   return { sendPixel };
+};
+
+export const useChatSocket = ({
+  onMessageReceived,
+  group_id,
+  user_id,
+}: ChatSocketProps) => {
+  const handleChatError = useCallback((error: any) => {
+    console.error('채팅 에러:', error);
+  }, []);
+
+  const { sendMessage } = useChatSocketHook(
+    onMessageReceived,
+    handleChatError,
+    group_id,
+    user_id
+  );
+
+  return { sendMessage };
 };

--- a/src/components/chat/ChatAPI.tsx
+++ b/src/components/chat/ChatAPI.tsx
@@ -7,11 +7,13 @@ export const chatService = {
    */
   async getChatInitMessages(canvasId: string) {
     try {
-      const response = await apiClient.get('/chat/init', {
+      const response = await apiClient.get('/init/chat', {
         params: { canvas_id: canvasId },
       });
       console.log(response);
-      return response.data;
+      // return response.data;
+      const { defaultGroupId, groups, messages } = response.data.data;
+      return { defaultGroupId, groups, messages };
     } catch (error) {
       console.error(`Failed to fetch message for chat ${canvasId}:`, error);
       throw error;
@@ -22,14 +24,14 @@ export const chatService = {
    * 특정 그룹의 메시지 목록
    * @param groupId - 조회할 그룹의 ID
    */
-  async getChatMessages(groupId: string) {
+  async getChatMessages(groupId: string, limit = 30) {
     try {
-      const response = await apiClient.get('/chat/messages', {
+      const response = await apiClient.get('/chat', {
         // 이 엔드포인트는 예시입니다.
-        params: { group_id: groupId },
+        params: { group_id: groupId, limit },
       });
       // 실제 API에서는 data.messages 형태로 올 수 있습니다.
-      return response.data.messages || response.data;
+      return response.data.messages;
     } catch (error) {
       console.error(`Failed to fetch messages for group ${groupId}:`, error);
       throw error;

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useAuthStore } from '../../store/authStrore';
 
 export type Message = {
   messageId: string;
@@ -11,8 +12,10 @@ export type Message = {
 };
 
 const MessageItem = React.memo(({ message }: { message: Message }) => {
-  const isMyMessage = message.user.userId === 'me'; // 'me'는 현재 사용자의 userId라고 가정
+  const currentUser = useAuthStore((state) => state.user);
+  const isMyMessage = message.user.userId === currentUser?.userId;
 
+  console.log(message.user.userId);
   const messageBubbleClasses = isMyMessage
     ? 'bg-blue-500 text-white rounded-lg py-2 px-3 max-w-[70%] self-end'
     : 'bg-gray-700 text-white rounded-lg py-2 px-3 max-w-[70%] self-start';
@@ -24,13 +27,20 @@ const MessageItem = React.memo(({ message }: { message: Message }) => {
   return (
     <div className={`flex flex-col ${messageContainerClasses} my-1`}>
       {!isMyMessage && (
-        <div className='text-xs text-gray-400 mb-1 ml-1'>{message.user.name}</div>
+        <div className='mb-1 ml-1 text-xs text-gray-400'>
+          {message.user.name}
+        </div>
       )}
       <div className={messageBubbleClasses}>
         <div>{message.content}</div>
         {message.timestamp && (
-          <div className={`text-right text-xs mt-1 ${isMyMessage ? 'text-blue-200' : 'text-gray-400'}`}>
-            {new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+          <div
+            className={`mt-1 text-right text-xs ${isMyMessage ? 'text-blue-200' : 'text-gray-400'}`}
+          >
+            {new Date(message.timestamp).toLocaleTimeString([], {
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
           </div>
         )}
       </div>

--- a/src/hooks/useChatSocket.ts
+++ b/src/hooks/useChatSocket.ts
@@ -1,0 +1,66 @@
+import { useEffect, useCallback } from 'react';
+import socketService from '../services/socketService';
+
+interface ChatMessage {
+  id: number;
+  user: { id: number; user_name: string };
+  message: string;
+  created_at: string;
+}
+
+interface ChatError {
+  message: string;
+}
+
+export const useChatSocket = (
+  onMessageReceived: (message: ChatMessage) => void,
+  onChatError: (error: ChatError) => void,
+  group_id: string,
+  user_id: string
+) => {
+  useEffect(() => {
+    // 빈 값이거나 anonymous면 소켓 연결 안 함
+    // if (!group_id || !user_id || group_id === '1' && user_id === 'anonymous') {
+    //   console.log('소켓 연결 스킵: 빈 값');
+    //   return;
+    // }
+
+    // 채팅 이벤트 리스너 등록
+    socketService.onChatMessage(onMessageReceived);
+    socketService.onChatError(onChatError);
+
+    // 채팅방 참여
+    socketService.joinChat({ group_id, user_id });
+    console.log(`채팅방 참여: group_id=${group_id}, user_id=${user_id}`);
+
+    return () => {
+      // 클린업 시 이벤트 리스너 제거
+      socketService.offChatMessage(onMessageReceived);
+      socketService.offChatError(onChatError);
+    };
+  }, [group_id, user_id, onMessageReceived, onChatError]);
+
+  const sendMessage = useCallback(
+    (message: string) => {
+      if (!group_id || !user_id) return;
+
+      // 실제 소켓 전송
+      socketService.sendChat({ group_id, user_id, message });
+
+      // 백엔드 없이 테스트: 3초 후 가짜 응답 시뮬레이션
+      setTimeout(() => {
+        const fakeResponse: ChatMessage = {
+          id: Date.now(),
+          user: { id: parseInt(user_id.split('@')[0]) || 123, user_name: user_id },
+          message: `"${message}"에 대한 내 응답`,
+          created_at: new Date().toISOString(),
+        };
+        console.log('가짜 메시지 수신 시뮬레이션:', fakeResponse);
+        onMessageReceived(fakeResponse);
+      }, 3000);
+    },
+    [group_id, user_id, onMessageReceived]
+  );
+
+  return { sendMessage };
+};

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -28,17 +28,60 @@ class SocketService {
     });
   }
 
-  // 픽셀 그리기 서버로 전송
+  //==== 픽셀 관련 ====//
+  //픽셀 드로잉 요청
   drawPixel(pixelData: PixelDataWithCanvas) {
     if (this.socket) {
       this.socket.emit('draw-pixel', pixelData);
     }
   }
 
-  // 다른 사용자 픽셀 변경 수신
+  // 
   onPixelUpdate(callback: (pixelData: PixelData) => void) {
     if (this.socket) {
       this.socket.on('pixel-update', callback);
+    }
+  }
+
+  //==== 채팅 관련 ====//
+  // 채팅방 참여
+  joinChat(data: { group_id: string; user_id: string }) {
+    if (this.socket) {
+      this.socket.emit('join_chat', data);
+    }
+  }
+
+  // 채팅 메시지 전송
+  sendChat(data: { group_id: string; user_id: string; message: string }) {
+    if (this.socket) {
+      this.socket.emit('send_chat', data);
+    }
+  }
+
+  // 채팅 메시지 수신
+  onChatMessage(callback: (message: any) => void) {
+    if (this.socket) {
+      this.socket.on('chat-message', callback);
+    }
+  }
+
+  // 채팅 에러 수신
+  onChatError(callback: (error: any) => void) {
+    if (this.socket) {
+      this.socket.on('chat-error', callback);
+    }
+  }
+
+  // 채팅 이벤트 리스너 제거
+  offChatMessage(callback: (message: any) => void) {
+    if (this.socket) {
+      this.socket.off('chat-message', callback);
+    }
+  }
+
+  offChatError(callback: (error: any) => void) {
+    if (this.socket) {
+      this.socket.off('chat-error', callback);
     }
   }
 


### PR DESCRIPTION
-chatService
getChatInitMessages에서 response.data.data를 언패킹해 { defaultGroupId, groups, messages } 형태로 리턴
limit 파라미터 추가하였습니다.
-useChatSocket
group_id·user_id 유효성 검사(if (!group_id || !user_id) return) 추가
- Chat 컴포넌트

useChatSocket 훅 호출 시 group_id: currentGroupId || '', user_id: user?.userId || ''로 빈 문자열 기반 스킵 처리

handleGroupChange에서 getChatMessages로 그룹 전환 시점에 메시지 리로드
![IMG_0995](https://github.com/user-attachments/assets/d346b029-3c6e-4b0e-bc02-a0d10da96cdb)
