### PR TITLE
[SCRUM-80] 웹소켓 채팅 기능 서버 연동 

### DIFF
--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -73,27 +73,6 @@ export default function Chat() {
       currentGroupId,
       userId: user?.userId,
     });
-
-    // 임시: 로컬에서 메시지 바로 추가 (백엔드 없이 테스트용)
-    // const localMessage: Message = {
-    //   messageId: Date.now().toString(),
-    //   user: { userId: user?.userId || 'local', name: user?.nickname || '나' },
-    //   content: text,
-    //   timestamp: new Date().toISOString(),
-    // };
-    // setMessages((prev) => [...prev, localMessage]);
-
-    const newMessage: Message = {
-      messageId: Date.now().toString(),
-      user: {
-        userId: user?.userId || 'anonymous',
-        name: user?.nickname || '나',
-      },
-      content: text,
-      timestamp: new Date().toISOString(),
-    };
-    setMessages((prev) => [...prev, newMessage]);
-    // 실제 소켓 전송 (백엔드 있을 때)
     if (currentGroupId && user?.userId) {
       sendSocketMessage(text);
     }
@@ -104,42 +83,27 @@ export default function Chat() {
   };
 
   // isOpen True 시, canvasId 변경시
-  // useEffect(() => {
-  //   console.log(`modal open, ${canvas_id}`);
-  //   if (isOpen && canvas_id) {
-  //     const fetchInitialData = async () => {
-  //       console.log(`start fetch, ${canvas_id}`);
-  //       try {
-  //         const {
-  //           defaultGroupId,
-  //           groups: fetchedGroups,
-  //           messages: initialMessages,
-  //         } = await chatService.getChatInitMessages(canvas_id);
-
-  //         setGroups(fetchedGroups);
-  //         setCurrentGroupId(defaultGroupId);
-  //         setMessages(initialMessages);
-  //       } catch (error) {
-  //         console.error('초기 채팅 데이터를 불러오는 데 실패했습니다.', error);
-  //       }
-  //     };
-
-  //     fetchInitialData();
-  //   }
-  // }, [isOpen, canvas_id]);
-
   useEffect(() => {
+    console.log(`modal open, ${canvas_id}`);
     if (isOpen && canvas_id) {
-      console.log(`modal open, using dummy data for canvasId: ${canvas_id}`);
-      const {
-        defaultGroupId,
-        groups: fetchedGroups,
-        messages: initialMessages,
-      } = DUMMY_RESPONSE.data;
+      const fetchInitialData = async () => {
+        console.log(`start fetch, ${canvas_id}`);
+        try {
+          const {
+            defaultGroupId,
+            groups: fetchedGroups,
+            messages: initialMessages,
+          } = await chatService.getChatInitMessages(canvas_id);
 
-      setGroups(fetchedGroups);
-      setCurrentGroupId(defaultGroupId);
-      setMessages(initialMessages);
+          setGroups(fetchedGroups);
+          setCurrentGroupId(defaultGroupId);
+          setMessages(initialMessages);
+        } catch (error) {
+          console.error('초기 채팅 데이터를 불러오는 데 실패했습니다.', error);
+        }
+      };
+
+      fetchInitialData();
     }
   }, [isOpen, canvas_id]);
 

--- a/src/components/chat/ChatAPI.tsx
+++ b/src/components/chat/ChatAPI.tsx
@@ -6,14 +6,20 @@ export const chatService = {
    * @param canvasId - 조회할 그룹의 ID
    */
   async getChatInitMessages(canvasId: string) {
+    console.log('getChatInitMessages 호출됨:', canvasId);
     try {
-      const response = await apiClient.get('/init/chat', {
+      console.log('API 요청 시작');
+      const response = await apiClient.get('/group/init/chat', {
         params: { canvas_id: canvasId },
       });
-      console.log(response);
-      // return response.data;
       const { defaultGroupId, groups, messages } = response.data.data;
-      return { defaultGroupId, groups, messages };
+      // 메시지를 시간순으로 정렬 (오래된 것부터)
+      const sortedMessages = messages.sort(
+        (a, b) =>
+          new Date(a.timestamp || a.created_at).getTime() -
+          new Date(b.timestamp || b.created_at).getTime()
+      );
+      return { defaultGroupId, groups, messages: sortedMessages };
     } catch (error) {
       console.error(`Failed to fetch message for chat ${canvasId}:`, error);
       throw error;
@@ -31,7 +37,13 @@ export const chatService = {
         params: { group_id: groupId, limit },
       });
       // 실제 API에서는 data.messages 형태로 올 수 있습니다.
-      return response.data.messages;
+      const messages = response.data.messages;
+      // 메시지를 시간순으로 정렬
+      return messages.sort(
+        (a, b) =>
+          new Date(a.timestamp || a.created_at).getTime() -
+          new Date(b.timestamp || b.created_at).getTime()
+      );
     } catch (error) {
       console.error(`Failed to fetch messages for group ${groupId}:`, error);
       throw error;

--- a/src/hooks/useChatSocket.ts
+++ b/src/hooks/useChatSocket.ts
@@ -46,20 +46,8 @@ export const useChatSocket = (
 
       // 실제 소켓 전송
       socketService.sendChat({ group_id, user_id, message });
-
-      // 백엔드 없이 테스트: 3초 후 가짜 응답 시뮬레이션
-      setTimeout(() => {
-        const fakeResponse: ChatMessage = {
-          id: Date.now(),
-          user: { id: parseInt(user_id.split('@')[0]) || 123, user_name: user_id },
-          message: `"${message}"에 대한 내 응답`,
-          created_at: new Date().toISOString(),
-        };
-        console.log('가짜 메시지 수신 시뮬레이션:', fakeResponse);
-        onMessageReceived(fakeResponse);
-      }, 3000);
     },
-    [group_id, user_id, onMessageReceived]
+    [group_id, user_id]
   );
 
   return { sendMessage };

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -1,4 +1,5 @@
 import { io, Socket } from 'socket.io-client';
+import { useAuthStore } from '../store/authStrore';
 
 interface PixelData {
   x: number;
@@ -14,8 +15,14 @@ class SocketService {
   private socket: Socket | null = null;
 
   connect(canvas_id: string) {
+    const { accessToken } = useAuthStore.getState();
     this.socket = io(
-      import.meta.env.VITE_SOCKET_URL || 'https://ws.pick-px.com'
+      import.meta.env.VITE_SOCKET_URL || 'https://ws.pick-px.com',
+      {
+        auth: {
+          token: accessToken,
+        },
+      }
     );
 
     this.socket.on('connect', () => {
@@ -36,7 +43,7 @@ class SocketService {
     }
   }
 
-  // 
+  //
   onPixelUpdate(callback: (pixelData: PixelData) => void) {
     if (this.socket) {
       this.socket.on('pixel-update', callback);


### PR DESCRIPTION
#### 웹소켓 JWT 인증 구현
- socketService.ts: 소켓 연결 시 authStore에서 JWT 토큰을 가져와 auth.token으로 전송
- 백엔드의 JWT 검증 로직과 연동하여 인증된 사용자만 채팅 참여 가능

#### 실제 서버 API 연동
- 더미 데이터 제거: DUMMY_RESPONSE 사용 코드 및 테스트용 가짜 메시지 시뮬레이션 코드 주석 처리

####  메시지 정렬 기능 추가
- ChatAPI.tsx: 받아온 메시지를 created_at 기준으로 시간순 정렬
- 초기 메시지 로딩과 그룹별 메시지 로딩 모두에 적용

#### API 경로 수정
- /init/chat → /group/init/chat로 경로 수정