### PR TITLE
[SCRUM-87] canvas 중복 요청 문제 해결 및 canvas_id 동기화

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,18 +51,18 @@ function App() {
 
       setIsLoading(false);
     } else {
-      // const checkLoginStatus = async () => {
-      //   try {
-      //     const response = await apiClient.post('/auth/refresh');
-      //     setAuth(response.data.accessToken, response.data.user);
-      //   } catch (error) {
-      //     // 실패 시 (유효한 RT 없음) 로그아웃 상태
-      //     clearAuth();
-      //   } finally {
-      //     setIsLoading(false);
-      //   }
-      // };
-      // checkLoginStatus();
+      const checkLoginStatus = async () => {
+        try {
+          const response = await apiClient.post('/auth/refresh');
+          setAuth(response.data.accessToken, response.data.user);
+        } catch (error) {
+          // 실패 시 (유효한 RT 없음) 로그아웃 상태
+          clearAuth();
+        } finally {
+          setIsLoading(false);
+        }
+      };
+      checkLoginStatus();
     }
   }, [setAuth, clearAuth]);
 

--- a/src/components/PixelCanvas.tsx
+++ b/src/components/PixelCanvas.tsx
@@ -18,7 +18,14 @@ type PixelCanvasProps = {
 function PixelCanvas({ canvas_id: initialCanvasId }: PixelCanvasProps) {
   const { canvas_id, setCanvasId } = useCanvasStore();
 
-  // const [canvas_id, setCanvasId] = useState(initialCanvasId);
+  // props로 받은 canvas_id를 store에 설정
+  useEffect(() => {
+    if (initialCanvasId && initialCanvasId !== canvas_id) {
+      setCanvasId(initialCanvasId);
+    }
+    console.log(`zustadn:${canvas_id}`);
+  }, [initialCanvasId, canvas_id, setCanvasId]);
+
   const rootRef = useRef<HTMLDivElement>(null);
   const previewCanvasRef = useRef<HTMLCanvasElement>(null);
   const renderCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -124,7 +131,11 @@ function PixelCanvas({ canvas_id: initialCanvasId }: PixelCanvasProps) {
     }
   }, [canvasSize]);
 
-  const { sendPixel } = usePixelSocket({ sourceCanvasRef, draw, canvas_id });
+  const { sendPixel } = usePixelSocket({
+    sourceCanvasRef,
+    draw,
+    canvas_id,
+  });
 
   const updateOverlay = useCallback(
     (screenX: number, screenY: number) => {
@@ -398,8 +409,9 @@ function PixelCanvas({ canvas_id: initialCanvasId }: PixelCanvasProps) {
   }, []);
 
   useEffect(() => {
-    fetchCanvasData(canvas_id);
-  }, [canvas_id, fetchCanvasData]);
+    // 최초 마운트 시 props로 받은 id로만 fetch
+    fetchCanvasData(initialCanvasId);
+  }, [initialCanvasId, fetchCanvasData]);
 
   useEffect(() => {
     const rootElement = rootRef.current;


### PR DESCRIPTION
## 문제
- 홈페이지 접속 시 canvas 데이터를 2번 요청하는 성능 문제
- canvas_id 상태가 중복 관리되어 불필요한 리렌더링 발생
- 
**호출 순서**
1. 첫 번째 렌더링: canvas_id = '' (빈 문자열)
- fetchCanvasData('') 호출 → 기본 캔버스 요청
2. URL 파싱 완료: canvas_id = '2'
- 의존성 배열 변경 감지
- fetchCanvasData('2') 호출 → 특정 캔버스 요청
3. fetchCanvasData 내부: setCanvasId(fetchedId)
- zustand store 업데이트로 인한 추가 리렌더링

## 해결
- fetchCanvasData에서 setCanvasId(fetchedId) 제거
- canvas_id는 zustand store에서만 관리

##개선 효과
- 성능 최적화 및 불필요한 네트워크 요청 제거



