### PR TITLE
[SCRUM-88] cooldown-time validation (synchronization)

### DIFF
--- a/src/components/PixelCanvas.tsx
+++ b/src/components/PixelCanvas.tsx
@@ -23,7 +23,7 @@ function PixelCanvas({ canvas_id: initialCanvasId }: PixelCanvasProps) {
     if (initialCanvasId && initialCanvasId !== canvas_id) {
       setCanvasId(initialCanvasId);
     }
-    console.log(`zustadn:${canvas_id}`);
+    console.log(`zustadn:${initialCanvasId}`);
   }, [initialCanvasId, canvas_id, setCanvasId]);
 
   const rootRef = useRef<HTMLDivElement>(null);
@@ -135,6 +135,17 @@ function PixelCanvas({ canvas_id: initialCanvasId }: PixelCanvasProps) {
     sourceCanvasRef,
     draw,
     canvas_id,
+    onCooldownReceived: (cooldownData) => {
+      console.log('쿨다운 정보 수신:', cooldownData);
+      console.log('쿨다운 체크:', cooldownData.cooldown === 'true');
+
+      if (cooldownData.cooldown) {
+        console.log(`쿨다운 시작: ${cooldownData.remaining}초`);
+        startCooldown(cooldownData.remaining);
+      } else {
+        console.log('쿨다운 없음');
+      }
+    },
   });
 
   const updateOverlay = useCallback(

--- a/src/components/SocketIntegration.tsx
+++ b/src/components/SocketIntegration.tsx
@@ -6,6 +6,7 @@ interface SocketIntegrationProps {
   sourceCanvasRef: React.RefObject<HTMLCanvasElement>;
   draw: () => void;
   canvas_id: string;
+  onCooldownReceived?: (cooldown: { cooldown: boolean; remaining: number }) => void;
 }
 
 interface ChatSocketProps {
@@ -23,6 +24,7 @@ export const usePixelSocket = ({
   sourceCanvasRef,
   draw,
   canvas_id,
+  onCooldownReceived,
 }: SocketIntegrationProps) => {
   const handlePixelReceived = useCallback(
     (pixel: { x: number; y: number; color: string }) => {
@@ -36,7 +38,7 @@ export const usePixelSocket = ({
     [sourceCanvasRef, draw]
   );
 
-  const { sendPixel } = useSocket(handlePixelReceived, canvas_id);
+  const { sendPixel } = useSocket(handlePixelReceived, canvas_id, onCooldownReceived);
 
   return { sendPixel };
 };

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -9,8 +9,8 @@ interface PixelData {
 }
 
 interface CooldownData {
-  cooldown: string;
-  remaining: string;
+  cooldown: boolean;
+  remaining: number;
 }
 
 export const useSocket = (
@@ -19,19 +19,33 @@ export const useSocket = (
   onCooldownReceived?: (cooldown: CooldownData) => void
 ) => {
   const { accessToken, user } = useAuthStore();
-  
+  const pixelCallbackRef = useRef(onPixelReceived);
+  const cooldownCallbackRef = useRef(onCooldownReceived);
+
+  // 콜백 함수 업데이트
+  pixelCallbackRef.current = onPixelReceived;
+  cooldownCallbackRef.current = onCooldownReceived;
+
   useEffect(() => {
     if (!canvas_id) return;
-    
+
+    console.log('소켓 연결 시도:', canvas_id);
+
     // 토큰이나 user 정보가 변경되면 소켓 재연결
     socketService.disconnect();
     socketService.connect(canvas_id);
-    socketService.onPixelUpdate(onPixelReceived);
-    
-    if (onCooldownReceived) {
-      socketService.onCooldownInfo(onCooldownReceived);
+    socketService.onPixelUpdate((pixel) => {
+      pixelCallbackRef.current(pixel);
+    });
+
+    if (cooldownCallbackRef.current) {
+      socketService.onCooldownInfo((cooldown) => {
+        cooldownCallbackRef.current?.(cooldown);
+      });
+    } else {
+      console.log('쿨다운 콜백 없음');
     }
-  }, [canvas_id, accessToken, user, onPixelReceived, onCooldownReceived]);
+  }, [canvas_id, accessToken, user]);
 
   const sendPixel = (pixel: PixelData) => {
     if (!canvas_id) return;

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -33,6 +33,10 @@ class SocketService {
     this.socket.on('disconnect', () => {
       console.log('소켓 연결 끊김');
     });
+
+    this.socket.on('connect_error', (error) => {
+      console.error('소켓 연결 실패:', error.message);
+    });
   }
 
   //==== 픽셀 관련 ====//
@@ -51,9 +55,11 @@ class SocketService {
   }
 
   //쿨다운 정보 수신
-  onCooldownInfo(callback: (data: { cooldown: string; remaining: string }) => void) {
+  onCooldownInfo(
+    callback: (data: { cooldown: boolean; remaining: number }) => void
+  ) {
     if (this.socket) {
-      this.socket.on('cooldown_info', callback);
+      this.socket.on('cooldown-info', callback);
     }
   }
 


### PR DESCRIPTION
### 1. 새로고침 시 쿨다운 동기화
- 소켓 연결 → join_canvas 이벤트
- 서버에서 cooldown_info 이벤트로 현재 쿨다운 상태 전송
- 클라이언트에서 수신하여 UI에 표시

### 2. 캔버스 이동 시 쿨다운 동기화
- canvas_id 변경 → 소켓 재연결
- 새로운 캔버스의 쿨다운 상태 수신
- 각 캔버스별 독립적인 쿨다운 관리
