### PR TITLE
[SCRUM-125]채팅창 닫기 후 캔버스 커서 미인식 문제 해결

### DIFF
--- a/src/components/canvas/PixelCanvas.tsx
+++ b/src/components/canvas/PixelCanvas.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useCallback, useState } from 'react';
 import { useCanvasUiStore } from '../../store/canvasUiStore';
+import { shallow } from 'zustand/shallow';
 import { usePixelSocket } from '../SocketIntegration';
 import CanvasUI from './CanvasUI';
 import Preloader from '../Preloader';
@@ -53,33 +54,41 @@ function PixelCanvas({
     color: string;
   } | null>(null);
 
+  // state를 각각 가져오도록 하여 불필요한 리렌더링을 방지합니다.
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
-  const {
-    color,
-    setColor,
-    hoverPos,
-    setHoverPos,
-    cooldown,
-    setCooldown,
-    timeLeft,
-    setTimeLeft,
-    showPalette,
-    setShowPalette,
-    showImageControls,
-    setShowImageControls,
-    isImageFixed,
-    setIsImageFixed,
-    imageMode,
-    setImageMode,
-    imageTransparency,
-    setImageTransparency,
-    isLoading,
-    setIsLoading,
-    hasError,
-    setHasError,
-    showCanvas,
-    setShowCanvas,
-  } = useCanvasUiStore();
+
+  const color = useCanvasUiStore((state) => state.color);
+  const setColor = useCanvasUiStore((state) => state.setColor);
+  const hoverPos = useCanvasUiStore((state) => state.hoverPos);
+  const setHoverPos = useCanvasUiStore((state) => state.setHoverPos);
+  const cooldown = useCanvasUiStore((state) => state.cooldown);
+  const setCooldown = useCanvasUiStore((state) => state.setCooldown);
+  const timeLeft = useCanvasUiStore((state) => state.timeLeft);
+  const setTimeLeft = useCanvasUiStore((state) => state.setTimeLeft);
+  const showPalette = useCanvasUiStore((state) => state.showPalette);
+  const setShowPalette = useCanvasUiStore((state) => state.setShowPalette);
+  const showImageControls = useCanvasUiStore(
+    (state) => state.showImageControls
+  );
+  const setShowImageControls = useCanvasUiStore(
+    (state) => state.setShowImageControls
+  );
+  const isImageFixed = useCanvasUiStore((state) => state.isImageFixed);
+  const setIsImageFixed = useCanvasUiStore((state) => state.setIsImageFixed);
+  const imageMode = useCanvasUiStore((state) => state.imageMode);
+  const setImageMode = useCanvasUiStore((state) => state.setImageMode);
+  const imageTransparency = useCanvasUiStore(
+    (state) => state.imageTransparency
+  );
+  const setImageTransparency = useCanvasUiStore(
+    (state) => state.setImageTransparency
+  );
+  const isLoading = useCanvasUiStore((state) => state.isLoading);
+  const setIsLoading = useCanvasUiStore((state) => state.setIsLoading);
+  const hasError = useCanvasUiStore((state) => state.hasError);
+  const setHasError = useCanvasUiStore((state) => state.setHasError);
+  const showCanvas = useCanvasUiStore((state) => state.showCanvas);
+  const setShowCanvas = useCanvasUiStore((state) => state.setShowCanvas);
 
   const imageTransparencyRef = useRef(0.5);
 
@@ -995,7 +1004,6 @@ function PixelCanvas({
                 ✕ 취소
               </button>
             </div>
-
             {/* 하단 안내 */}
             <div className='mt-3 border-t border-gray-700/50 pt-3 text-center text-xs text-gray-400'>
               확정하면 픽셀 그리기가 가능합니다

--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -129,7 +129,7 @@ function Chat() {
   }, [isOpen, canvas_id]);
 
   return (
-    <div className='fixed bottom-4 left-2 z-50 flex flex-col items-start'>
+    <div className={`fixed bottom-4 left-2 z-50 flex flex-col items-start ${!isOpen ? 'pointer-events-none' : ''}`}>
       {/* 채팅창 UI */}
       <div
         className={`mb-2 flex h-[500px] w-80 flex-col rounded-xl border border-white/30 bg-black/30 shadow-2xl backdrop-blur-md transition-all duration-300 ease-in-out ${isOpen ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-4 opacity-0'}`}
@@ -192,7 +192,7 @@ function Chat() {
           }
           setIsOpen(!isOpen);
         }}
-        className='flex h-10 w-10 items-center justify-center rounded-full bg-blue-500 text-white shadow-xl transition-transform hover:bg-blue-600 active:scale-90'
+        className='flex h-10 w-10 items-center justify-center rounded-full bg-blue-500 text-white shadow-xl transition-transform hover:bg-blue-600 active:scale-90 pointer-events-auto'
       >
         {isOpen ? (
           // 닫기 아이콘 (X)


### PR DESCRIPTION

  문제 설명:
  캔버스를 확대한 상태에서 채팅 모달을 열었다 닫으면, 채팅창이 위치했던 영역에서 픽셀을 클릭하여 그릴 수 없는 문제가 발생


  원인:
  Chat 컴포넌트의 최상위 div (채팅창 전체를 감싸는 요소)가 fixed 포지션과 높은 z-index를 가지고 있었으며,
  isOpen 상태가 false (채팅창이 닫힌 상태)일 때도 기본 pointer-events: auto 속성을 유지. 
이로 인해 채팅창이 시각적으로는 숨겨졌지만, 해당 영역의 마우스 이벤트를 계속 가로채어 
하단의 캔버스로 이벤트가 전달되지 못했음.


  해결 방안:
   1. `Chat` 컴포넌트 최상위 `div`의 `pointer-events` 제어: isOpen 상태가 false일 때 최상위 div에
      pointer-events-none 클래스를 적용하여 마우스 이벤트를 통과시키도록 수정했습니다.
   2. 채팅창 여닫기 버튼의 `pointer-events` 명시: 채팅창 여닫기 버튼은 항상 클릭 가능해야 하므로, 해당
      버튼에 pointer-events-auto를 명시적으로 추가했습니다.


  이 변경을 통해 채팅창이 닫혔을 때는 해당 영역의 마우스 이벤트가 캔버스로 정상적으로 전달되어 픽셀을 그릴
  수 있게 됩니다.


  확인 방법:
   1. 캔버스 페이지로 이동합니다.
   2. 캔버스를 확대합니다.
   3. 채팅창을 열었다가 닫습니다.
   4. 채팅창이 위치했던 영역에 픽셀을 클릭하여 그릴 수 있는지 확인합니다.