### PR TITLE
[SCRUM-131]  socket-error-toast

### DIFF
--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import socketService from '../services/socketService';
 import { useAuthStore } from '../store/authStrore';
+import { toast } from 'react-toastify';
 
 interface PixelData {
   x: number;
@@ -13,14 +14,16 @@ interface CooldownData {
   remaining: number;
 }
 
+//canvas_id : zustand 동기화 수정 예정
 export const useSocket = (
   onPixelReceived: (pixel: PixelData) => void,
   canvas_id: string | undefined,
   onCooldownReceived?: (cooldown: CooldownData) => void
 ) => {
-  const { accessToken, user } = useAuthStore();
+  const { accessToken } = useAuthStore();
   const pixelCallbackRef = useRef(onPixelReceived);
   const cooldownCallbackRef = useRef(onCooldownReceived);
+  const [isConnected, setIsConnected] = useState(false);
 
   // 콜백 함수 업데이트
   pixelCallbackRef.current = onPixelReceived;
@@ -29,23 +32,53 @@ export const useSocket = (
   useEffect(() => {
     if (!canvas_id) return;
 
-    console.log('소켓 연결 시도:', canvas_id);
+    // 이미 연결된 경우 중복 연결 방지
+    if (isConnected) return;
 
     // 토큰이나 user 정보가 변경되면 소켓 재연결
     socketService.disconnect();
     socketService.connect(canvas_id);
+    setIsConnected(true);
+
+    // 픽셀 업데이트 이벤트 리스너
     socketService.onPixelUpdate((pixel) => {
       pixelCallbackRef.current(pixel);
     });
 
+    // 쿨다운 정보 이벤트 리스너
     if (cooldownCallbackRef.current) {
       socketService.onCooldownInfo((cooldown) => {
         cooldownCallbackRef.current?.(cooldown);
       });
-    } else {
-      console.log('쿨다운 콜백 없음');
     }
-  }, [canvas_id, accessToken, user]);
+
+    // 인증 에러 이벤트 리스너
+    socketService.onAuthError((error) => {
+      toast.error(`인증 오류: ${error.message}`);
+    });
+
+    // 픽셀 에러 이벤트 리스너
+    socketService.onPixelError((error) => {
+      if (error.remaining) {
+        toast.warning(
+          `픽셀 오류: ${error.message} (남은 시간: ${error.remaining}초)`
+        );
+      } else {
+        toast.error(`픽셀 오류: ${error.message}`);
+      }
+    });
+
+    // 채팅 에러 이벤트 리스너
+    socketService.onChatError((error) => {
+      toast.error(`채팅 오류: ${error.message}`);
+    });
+
+    // 컴포넌트 언마운트 시 정리
+    return () => {
+      socketService.disconnect();
+      setIsConnected(false);
+    };
+  }, [canvas_id, accessToken]);
 
   const sendPixel = (pixel: PixelData) => {
     if (!canvas_id) return;

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -39,27 +39,47 @@ class SocketService {
     });
   }
 
+  disconnect() {
+    if (this.socket) {
+      this.socket.disconnect();
+    }
+  }
+
   //==== 픽셀 관련 ====//
-  //픽셀 드로잉 요청
+  // 픽셀 드로잉 요청
   drawPixel(pixelData: PixelDataWithCanvas) {
     if (this.socket) {
       this.socket.emit('draw_pixel', pixelData);
     }
   }
-
-  //픽셀 업데이트 수신
+  // 픽셀 업데이트 수신
   onPixelUpdate(callback: (pixelData: PixelData) => void) {
     if (this.socket) {
       this.socket.on('pixel_update', callback);
     }
   }
-
-  //쿨다운 정보 수신
+  // 쿨다운 정보 수신
   onCooldownInfo(
     callback: (data: { cooldown: boolean; remaining: number }) => void
   ) {
     if (this.socket) {
       this.socket.on('cooldown_info', callback);
+    }
+  }
+  // 픽셀 에러 수신 (쿨다운 중, 서버 오류 등)
+  onPixelError(
+    callback: (error: { message: string; remaining?: number }) => void
+  ) {
+    if (this.socket) {
+      this.socket.on('pixel_error', callback);
+    }
+  }
+  // 픽셀 에러 리스너 제거
+  offPixelError(
+    callback: (error: { message: string; remaining?: number }) => void
+  ) {
+    if (this.socket) {
+      this.socket.off('pixel_error', callback);
     }
   }
 
@@ -70,50 +90,54 @@ class SocketService {
       this.socket.emit('join_chat', data);
     }
   }
-
+  // 채팅방 나가기
   leaveChat(data: { group_id: string }) {
     if (this.socket) {
       this.socket.emit('leave_chat', data);
     }
   }
-
   // 채팅 메시지 전송
   sendChat(data: { group_id: string; message: string }) {
     if (this.socket) {
       this.socket.emit('send_chat', data);
     }
   }
-
   // 채팅 메시지 수신
   onChatMessage(callback: (message: any) => void) {
     if (this.socket) {
       this.socket.on('chat_message', callback);
     }
   }
-
-  // 채팅 에러 수신
-  onChatError(callback: (error: any) => void) {
-    if (this.socket) {
-      this.socket.on('chat_error', callback);
-    }
-  }
-
-  // 채팅 이벤트 리스너 제거
+  // 채팅 메시지 리스너 제거
   offChatMessage(callback: (message: any) => void) {
     if (this.socket) {
       this.socket.off('chat_message', callback);
     }
   }
-
-  offChatError(callback: (error: any) => void) {
+  // 채팅 에러 수신
+  onChatError(callback: (error: { message: string }) => void) {
+    if (this.socket) {
+      this.socket.on('chat_error', callback);
+    }
+  }
+  // 채팅 에러 리스너 제거
+  offChatError(callback: (error: { message: string }) => void) {
     if (this.socket) {
       this.socket.off('chat_error', callback);
     }
   }
 
-  disconnect() {
+  //==== 인증 관련 ====//
+  // 인증 에러 수신 (유저 정보가 없거나 JWT토큰 파싱에 실패한 경우)
+  onAuthError(callback: (error: { message: string }) => void) {
     if (this.socket) {
-      this.socket.disconnect();
+      this.socket.on('auth_error', callback);
+    }
+  }
+  // 인증 에러 리스너 제거
+  offAuthError(callback: (error: { message: string }) => void) {
+    if (this.socket) {
+      this.socket.off('autherror', callback);
     }
   }
 }


### PR DESCRIPTION
- 소켓 관련 에러(auth-error, pixel-error, chat-error)를 toast로 표시하도록 처리하였습니다.
- 로그인하지 않은 상태에서 픽셀 색칠 시 클라이언트 측에서 먼저 확인하여 에러 메시지를 표시합니다. 
( 로그인 하지 않은 상태에서는 확정 버튼을 누르지 못하도록 되어있음. )
- 소켓 연결 로직을 개선하여 중복 연결을 방지하고 컴포넌트 언마운트 시 연결을 정리합니다.
