### PR TITLE
[SCRUM-133]PixelCanvas 리팩토링 : 쿨다운 로직 store 이동

### DIFF
--- a/src/components/canvas/PixelCanvas.tsx
+++ b/src/components/canvas/PixelCanvas.tsx
@@ -90,6 +90,8 @@ function PixelCanvas({
   const showCanvas = useCanvasUiStore((state) => state.showCanvas);
   const setShowCanvas = useCanvasUiStore((state) => state.setShowCanvas);
 
+  const startCooldown = useCanvasUiStore((state) => state.startCooldown);
+
   const imageTransparencyRef = useRef(0.5);
 
   // 이미지 관련 상태 (Zustand로 이동하지 않는 부분)
@@ -528,22 +530,6 @@ function PixelCanvas({
     },
     [draw, updateOverlay, canvasSize]
   );
-
-  const startCooldown = useCallback((seconds: number) => {
-    setCooldown(true);
-    setTimeLeft(seconds);
-
-    const timer = setInterval(() => {
-      setTimeLeft((prev) => {
-        if (prev <= 1) {
-          clearInterval(timer);
-          setCooldown(false);
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-  }, []);
 
   const handleCooltime = useCallback(() => {
     startCooldown(10);

--- a/src/store/canvasUiStore.ts
+++ b/src/store/canvasUiStore.ts
@@ -3,16 +3,19 @@ import { create } from 'zustand';
 type HoverPos = { x: number; y: number } | null;
 
 interface CanvasUiState {
+  // 선택 색상 상태
   color: string;
   setColor: (color: string) => void;
+  // 캔버스 내 좌표 값
   hoverPos: HoverPos;
   setHoverPos: (pos: HoverPos) => void;
-  cooldown: boolean;
-  setCooldown: (cooldown: boolean) => void;
+  // 잔여 쿨다운 시간
   timeLeft: number;
   setTimeLeft: (timeLeft: number | ((prev: number) => number)) => void;
+  // 색상 선택 팔레트
   showPalette: boolean;
   setShowPalette: (show: boolean) => void;
+  // 이미지 Overlay Guide
   showImageControls: boolean;
   setShowImageControls: (show: boolean) => void;
   isImageFixed: boolean;
@@ -21,25 +24,33 @@ interface CanvasUiState {
   setImageMode: (mode: boolean) => void;
   imageTransparency: number;
   setImageTransparency: (transparency: number) => void;
+  // Loading 중, error 발생 확인
   isLoading: boolean;
   setIsLoading: (loading: boolean) => void;
   hasError: boolean;
   setHasError: (error: boolean) => void;
   showCanvas: boolean;
   setShowCanvas: (show: boolean) => void;
+  // CoolDown
+  cooldown: boolean;
+  setCooldown: (cooldown: boolean) => void;
+  startCooldown: (seconds: number) => void;
 }
 
-export const useCanvasUiStore = create<CanvasUiState>((set) => ({
+export const useCanvasUiStore = create<CanvasUiState>((set, get) => ({
   color: '#ffffff',
   setColor: (color) => set({ color }),
   hoverPos: null,
   setHoverPos: (hoverPos) => set({ hoverPos }),
-  cooldown: false,
-  setCooldown: (cooldown) => set({ cooldown }),
+
   timeLeft: 0,
-  setTimeLeft: (newTimeLeft) => set((state) => ({
-    timeLeft: typeof newTimeLeft === 'function' ? newTimeLeft(state.timeLeft) : newTimeLeft,
-  })),
+  setTimeLeft: (newTimeLeft) =>
+    set((state) => ({
+      timeLeft:
+        typeof newTimeLeft === 'function'
+          ? newTimeLeft(state.timeLeft)
+          : newTimeLeft,
+    })),
   showPalette: false,
   setShowPalette: (showPalette) => set({ showPalette }),
   showImageControls: false,
@@ -56,4 +67,21 @@ export const useCanvasUiStore = create<CanvasUiState>((set) => ({
   setHasError: (hasError) => set({ hasError }),
   showCanvas: false,
   setShowCanvas: (showCanvas) => set({ showCanvas }),
+  cooldown: false,
+  setCooldown: (cooldown) => set({ cooldown }),
+  startCooldown: (seconds: number) => {
+    if (get().cooldown) return;
+
+    set({ cooldown: true, timeLeft: seconds });
+
+    const timer = setInterval(() => {
+      const newTimeLeft = get().timeLeft - 1;
+      if (newTimeLeft <= 0) {
+        clearInterval(timer);
+        set({ cooldown: false, timeLeft: 0 });
+      } else {
+        set({ timeLeft: newTimeLeft });
+      }
+    }, 1000);
+  },
 }));


### PR DESCRIPTION
- 로직과 상태 함께 두기 (Co-location):

컴포넌트 내부에 존재하던 startCooldown 로직(setInterval 포함)을 useCanvasUiStore의 **액션(action)**으로 이전
이제 쿨타임 관련 로직은 스토어가 책임을 지게 되며, 컴포넌트는 해당 액션을 호출하는 방식으로 책임 분산