### PR TITLE
[SCRUM-154]:모바일 safari 기본 동작 방지 및 Pinch Zoom 대응

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/main_logo.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,7 @@ function App() {
   }, [setAuth, clearAuth]);
 
   return (
-    <main className='flex h-screen w-screen items-center justify-center bg-[#2d3748]'>
+    <main className='touch-action-none flex h-screen w-screen items-center justify-center bg-[#2d3748]'>
       <PixelCanvas
         canvas_id={canvas_id}
         key={canvas_id}

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,21 @@
 @import 'tailwindcss';
-body,
 html,
-#root {
+body {
+  overflow: hidden; /* 스크롤바를 숨기고 스크롤 동작을 비활성화 */
+  overscroll-behavior: none; /* 오버스크롤 효과도 비활성화 */
+  touch-action: none; /* 혹시 모를 경우를 대비해 전역적으로 추가 */
   width: 100%;
   height: 100%;
   margin: 0;
   padding: 0;
   background-color: #1e293b; /* Tailwind CSS의 slate-800 색상입니다. */
+}
+
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 /* Custom Scrollbar for Webkit browsers */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,4 +4,14 @@ import './index.css';
 
 import Router from './router/router.tsx';
 
+// iOS Safari 웹뷰에서 핀치 줌 및 스크롤 방지
+
+document.addEventListener(
+  'touchmove',
+  (event) => {
+    event.preventDefault();
+  },
+  { passive: false }
+);
+
 createRoot(document.getElementById('root')!).render(<Router />);


### PR DESCRIPTION
- Safari는 meta 태그를 활용한 기본 배율 설정이 불가능한 것을 확인, 
- 카카오 기술블로그 참고하여 기본 동작 적용 안되도록 수정하였습니다.

> https://tech.kakaoent.com/front-end/2023/230310-webview-pinch-zoom/