### PR TITLE
[SCRUM-246] pixel-update-array

### DIFF
--- a/src/components/SocketIntegration.tsx
+++ b/src/components/SocketIntegration.tsx
@@ -6,6 +6,9 @@ interface SocketIntegrationProps {
   sourceCanvasRef: React.RefObject<HTMLCanvasElement>;
   draw: () => void;
   canvas_id: string;
+  onPixelReceived?: (data: {
+    pixels: Array<{ x: number; y: number; color: string }>;
+  }) => void;
   onCooldownReceived?: (cooldown: {
     cooldown: boolean;
     remaining: number;
@@ -28,23 +31,38 @@ export const usePixelSocket = ({
   sourceCanvasRef,
   draw,
   canvas_id,
+  onPixelReceived,
   onCooldownReceived,
 }: SocketIntegrationProps) => {
   const handlePixelReceived = useCallback(
-    (pixel: { x: number; y: number; color: string }) => {
+    (data: any) => {
+      // 외부에서 제공된 onPixelReceived 콜백이 있으면 사용
+      if (onPixelReceived) {
+        onPixelReceived(data);
+        return;
+      }
+
+      // 기본 동작: 소스 캔버스에 직접 그리기
+      const { pixels } = data;
       const sourceCtx = sourceCanvasRef.current?.getContext('2d');
       if (sourceCtx) {
-        sourceCtx.fillStyle = pixel.color;
-        sourceCtx.fillRect(pixel.x, pixel.y, 1, 1);
+        // 각 픽셀에 대해 그리기
+        pixels.forEach((pixel: { x: number; y: number; color: string }) => {
+          // 소스 캔버스에 픽셀 그리기
+          sourceCtx.fillStyle = pixel.color;
+          sourceCtx.fillRect(pixel.x, pixel.y, 1, 1);
+        });
+
+        // 캔버스 다시 그리기
         draw();
       }
     },
-    [sourceCanvasRef, draw]
+    [sourceCanvasRef, draw, onPixelReceived]
   );
 
   const { sendPixel } = useSocket(
-    handlePixelReceived,
     canvas_id,
+    handlePixelReceived,
     onCooldownReceived
   );
 

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -18,8 +18,10 @@ interface CooldownData {
 
 //canvas_id : zustand 동기화 수정 예정
 export const useSocket = (
-  onPixelReceived: (pixel: PixelData) => void,
   canvas_id: string | undefined,
+  onPixelReceived?: (data: {
+    pixels: Array<{ x: number; y: number; color: string }>;
+  }) => void,
   onCooldownReceived?: (cooldown: CooldownData) => void
 ) => {
   const { accessToken, user } = useAuthStore();
@@ -45,10 +47,12 @@ export const useSocket = (
     socketService.connect(canvas_id);
     setIsConnected(true);
 
-    // 픽셀 업데이트 이벤트 리스너
-    socketService.onPixelUpdate((pixel) => {
-      pixelCallbackRef.current(pixel);
-    });
+    // 픽셀 더미 업데이트
+    if (pixelCallbackRef.current) {
+      socketService.OnPixelUpdate((data) => {
+        pixelCallbackRef.current?.(data);
+      });
+    }
 
     // 쿨다운 정보 이벤트 리스너
     if (cooldownCallbackRef.current) {

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -55,11 +55,12 @@ class SocketService {
     }
   }
   // 픽셀 업데이트 수신
-  onPixelUpdate(callback: (pixelData: PixelData) => void) {
+  OnPixelUpdate(callback: (data: { pixels: Array<PixelData> }) => void) {
     if (this.socket) {
       this.socket.on('pixel_update', callback);
     }
   }
+
   // 쿨다운 정보 수신
   onCooldownInfo(
     callback: (data: { cooldown: boolean; remaining: number }) => void
@@ -198,7 +199,7 @@ class SocketService {
   // 게임 픽셀 업데이트 수신
   onGamePixelUpdate(callback: (pixelData: PixelData) => void) {
     if (this.socket) {
-      this.socket.on('pixel_update', (data) => {
+      this.socket.on('game_pixel_update', (data) => {
         console.log(
           'SocketService: Received pixel_update for game canvas',
           data


### PR DESCRIPTION
# 소켓 통신 개선 및 게임 이벤트 분리

## 주요 변경사항

### 1. 픽셀 수신 방식 개선
- 기존: 하나의 픽셀을 개별적으로 수신하여 처리
- 변경: 여러 픽셀을 배열로 한 번에 수신하여 처리하도록 개선
  - `pixels` 배열을 받아 한 번에 처리하는 방식으로 변경
  - 네트워크 트래픽 감소 및 성능 향상 기대

### 2. 소스 반영 및 렌더링 최적화
- 기존: 픽셀 수신마다 개별적으로 소스에 반영 후 매번 draw() 호출
- 변경: 여러 픽셀을 소스에 일괄 반영 후 한 번만 draw() 호출
  - 불필요한 렌더링 감소로 성능 개선
  - `pixels.forEach`로 모든 픽셀을 처리한 후 한 번만 draw() 호출

### 3. 게임 이벤트 분리
- 기존: 일반 픽셀 처리와 게임 이벤트가 혼합되어 있음
- 변경: 게임 이벤트 처리 로직을 별도로 분리
