### PR TITLE
[SCRUM-248] 문제 모달 엔터키 버그 수정

### DIFF
--- a/src/components/game/GameCanvas.tsx
+++ b/src/components/game/GameCanvas.tsx
@@ -1117,6 +1117,7 @@ function GameCanvas({
     DRAG_THRESHOLD,
     handleConfirm,
     isGameMode: true, // 게임 모드 활성화
+    showQuestionModal, // 문제 모달 상태 전달
   });
 
   // 게임 나가기 핸들러

--- a/src/hooks/useCanvasInteraction.ts
+++ b/src/hooks/useCanvasInteraction.ts
@@ -59,6 +59,7 @@ interface UseCanvasInteractionProps {
 
   // Game mode
   isGameMode?: boolean;
+  showQuestionModal?: boolean;
 }
 
 export const useCanvasInteraction = ({
@@ -94,6 +95,7 @@ export const useCanvasInteraction = ({
   DRAG_THRESHOLD,
   handleConfirm,
   isGameMode = false,
+  showQuestionModal = false,
 }: UseCanvasInteractionProps) => {
   // Refs managed within the hook
   const isPanningRef = useRef<boolean>(false);
@@ -461,7 +463,7 @@ export const useCanvasInteraction = ({
           moved = true;
           break;
         case 'Enter':
-          if (!isChatOpen && !cooldown && isLoggedIn) {
+          if (!isChatOpen && !cooldown && isLoggedIn && !showQuestionModal) {
             handleConfirm();
           }
           break;
@@ -485,7 +487,7 @@ export const useCanvasInteraction = ({
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [draw, handleConfirm, canvasSize, isChatOpen]);
+  }, [draw, handleConfirm, canvasSize, isChatOpen, showQuestionModal]);
 
   useEffect(() => {
     const interactionCanvas = interactionCanvasRef.current;


### PR DESCRIPTION
# Fix: QuestionModal 열린 상태에서 Enter키로 문제 변경되는 버그 수정

## 문제 원인
- GameCanvas에서 문제 모달이 열려있는데 Enter키를 누르면 새로운 문제로 바뀜
- `useCanvasInteraction`에서 window에 등록한 키보드 이벤트가 모달 상태를 체크하지 않아서 발생
- QuestionModal의 `preventDefault()`는 window 레벨 이벤트를 막을 수 없음

## 해결책
- `useCanvasInteraction`에 `showQuestionModal` 상태 전달
- Enter키 처리 시 문제 모달이 열려있으면 `handleConfirm()` 실행 차단

## 수정 사항

### `useCanvasInteraction.ts`
```typescript
// 인터페이스에 showQuestionModal 추가
interface UseCanvasInteractionProps {
  // ...
+ showQuestionModal?: boolean;
}

// Enter키 처리 조건 수정
case 'Enter':
- if (!isChatOpen && !cooldown && isLoggedIn) {
+ if (!isChatOpen && !cooldown && isLoggedIn && !showQuestionModal) {
    handleConfirm();
  }
```

### `GameCanvas.tsx`
```typescript
// showQuestionModal 상태 전달
useCanvasInteraction({
  // ...
+ showQuestionModal,
});
```

## 결과
- 문제 모달이 열려있을 때 Enter키로 문제가 바뀌지 않음
- 사용자가 안전하게 문제를 풀 수 있음