### PR TITLE
[SCRUM-250] 모바일 환경 채팅창 스크롤 기능 추가

### DIFF
--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -194,7 +194,16 @@ function Chat() {
     >
       {/* 채팅창 UI */}
       <div
-        className={`mb-2 flex h-[500px] w-80 flex-col rounded-xl border border-white/30 bg-black/30 shadow-2xl backdrop-blur-md transition-all duration-300 ease-in-out ${isOpen ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-4 opacity-0'}`}
+        className={`mb-2 flex w-80 flex-col rounded-xl border border-white/30 bg-black/30 shadow-2xl backdrop-blur-md transition-all duration-300 ease-in-out ${isOpen ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-4 opacity-0'}`}
+        style={{
+          touchAction: 'manipulation',
+          height: '500px',
+          maxHeight: '500px',
+          position: 'relative',
+          zIndex: 50,
+        }}
+        onTouchStart={(e) => e.stopPropagation()}
+        onTouchMove={(e) => e.stopPropagation()}
       >
         <div className='flex h-full flex-col'>
           {/* 헤더: 동적 제목 표시 */}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -7,13 +7,61 @@ type MessageListProps = {
 
 export default function MessageList({ messages }: MessageListProps) {
   const listEndRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     listEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  // iOS Safari 터치 스크롤을 강제로 활성화
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+
+    // 전역 touch-action을 무시하고 강제로 스크롤 활성화
+    element.style.touchAction = 'pan-y';
+    (element.style as any).webkitOverflowScrolling = 'touch';
+
+    const handleTouchStart = (e: TouchEvent) => {
+      // 이벤트 전파를 막아 전역 설정 우회
+      e.stopPropagation();
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      // 이벤트 전파를 막아 전역 설정 우회
+      e.stopPropagation();
+    };
+
+    element.addEventListener('touchstart', handleTouchStart, {
+      passive: true,
+      capture: true,
+    });
+    element.addEventListener('touchmove', handleTouchMove, {
+      passive: true,
+      capture: true,
+    });
+
+    return () => {
+      element.removeEventListener('touchstart', handleTouchStart, true);
+      element.removeEventListener('touchmove', handleTouchMove, true);
+    };
+  }, []);
+
   return (
-    <div className='flex-grow overflow-y-auto rounded-lg p-3'>
+    <div
+      ref={scrollRef}
+      className='flex-1 rounded-lg p-3'
+      style={{
+        overflow: 'auto',
+        WebkitOverflowScrolling: 'touch',
+        touchAction: 'pan-y',
+        height: '320px',
+        maxHeight: '320px',
+        minHeight: '320px',
+        position: 'relative',
+        zIndex: 1,
+      }}
+    >
       {messages.map((msg) => (
         <MessageItem key={msg.messageId} message={msg} />
       ))}


### PR DESCRIPTION
## 📱 [SCRUM-250] 모바일 환경 채팅창 스크롤 기능 추가

### 🐛 문제
- iOS Safari에서 채팅창 내 메시지 목록을 스크롤할 수 없는 문제
- 전역 CSS `touch-action: none` 설정으로 인해 터치 드래그 스크롤이 비활성화됨

### ✅ 해결
- **MessageList.tsx**: iOS Safari 터치 스크롤 강제 활성화
  - `capture: true` 옵션으로 터치 이벤트 우선 처리
  - `stopPropagation()`으로 전역 터치 설정 무력화
  - 명시적 높이 설정 및 `touchAction: 'pan-y'` 적용

- **Chat.tsx**: 채팅창 전체 터치 이벤트 개선  
  - React 터치 이벤트 핸들러 추가
  - `zIndex` 우선순위 조정


[SCRUM-250]: https://pick-px.atlassian.net/browse/SCRUM-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ